### PR TITLE
Fix conversation message attachments not scanned bug

### DIFF
--- a/jobs/process_email_webhook_job.rb
+++ b/jobs/process_email_webhook_job.rb
@@ -12,6 +12,9 @@ class ProcessEmailWebhookJob
 
   sig { params(message: EmailProvider::Message).void }
   def self.perform(message)
+    # Here is where the message would be uploaded
+    UploadEmailAttachmentsForScanService.run(message)
+
     # Tip: if you want step-by-step debugging, you can uncomment this line here.
     # Docs: https://github.com/deivid-rodriguez/pry-byebug#commands
     # binding.pry
@@ -19,9 +22,6 @@ class ProcessEmailWebhookJob
 
     # If there's no attachments then there's nothing to scan
     return if message.attachments.blank?
-
-    # Here is where the message would be uploaded
-    UploadEmailAttachmentsForScanService.run(message)
   end
 
   sig { params(message: EmailProvider::Message).void }
@@ -29,7 +29,7 @@ class ProcessEmailWebhookJob
     # Exclamation marks mean an error will be thrown if the operation fails
     Email.create!(
       external_id: message.id,
-      conversation: Conversation.find_by!(external_id: message.conversation_id),
+      conversation: Conversation.find_by!(external_id: message.conversation_id)
     )
   end
 

--- a/spec/jobs/process_email_webhook_job_spec.rb
+++ b/spec/jobs/process_email_webhook_job_spec.rb
@@ -37,5 +37,12 @@ RSpec.describe ProcessEmailWebhookJob do
                                                        Email.count
                                                      }.by(1)
     end
+
+    it "scans the attachment" do
+      described_class.perform(message)
+      expect(CreateAttachmentScanService).to have_received(:run).once.with(
+        message.attachments.first
+      )
+    end
   end
 end


### PR DESCRIPTION
Order matters. Previously we were saving the `Email` first. In UploadEmailAttachmentsForScanService, that runs `CreateAttachmentScanService` for each of message's attachments, we were checking if `Email` already existed, and considered it 'scanned' if so.