### PR TITLE
Introduce title v2 scan

### DIFF
--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -63,6 +63,17 @@ FactoryBot.define do
                 "score": 0.955939669149689,
                 "scan-key": "ContractTitle",
                 "text": "This Non-Disclosure Agrement, together with..."
+            },
+            {
+                "extracted-values": [
+                    {
+                        "normalized-value": "Contractor Agreement",
+                        "score": 0.9,
+                        "text": "Non-Disclosure Agreement"
+                    }
+                ],
+                "scan-key": "ContractTitle_V2",
+                "text": "This Contractor Agreement, together with..."
             }
         ]
     }
@@ -115,7 +126,17 @@ FactoryBot.define do
       after(:build) do |result|
         parsed_result = JSON.parse(result.raw_result)
         parsed_result["results"].
-          reject! { |r| r["scan-key"] == "ContractTitle" }
+          reject! { |r| r["scan-key"] == "ContractTitle" }.
+          reject! { |r| r["scan-key"] == "ContractTitle_V2" }
+        result.raw_result = parsed_result.to_json
+      end
+    end
+
+    trait :no_title_v2_results do
+      after(:build) do |result|
+        parsed_result = JSON.parse(result.raw_result)
+        parsed_result["results"].
+          reject! { |r| r["scan-key"] == "ContractTitle_V2" }
         result.raw_result = parsed_result.to_json
       end
     end

--- a/spec/models/contract_scan_result_spec.rb
+++ b/spec/models/contract_scan_result_spec.rb
@@ -10,7 +10,9 @@ RSpec.describe ContractScanResult do
   end
 
   # See spec/factories.rb for an example of mocking
-  let(:contract_scan_result) { FactoryBot.build(:contract_scan_result) }
+  let(:contract_scan_result) do
+    FactoryBot.build(:contract_scan_result, :no_title_v2_results)
+  end
 
   it "sets the contract type" do
     expect(result.type).to eq "Non-Disclosure Agreement"
@@ -24,9 +26,18 @@ RSpec.describe ContractScanResult do
     expect(result).to be_full_contract_info
   end
 
+  context "with v2 contract scan" do
+    let(:contract_scan_result) { FactoryBot.build(:contract_scan_result) }
+
+    it "sets the contract type" do
+      expect(result.type).to eq "Contractor Agreement"
+    end
+  end
+
   context "when contract scan returns the two possible contract titles" do
     let(:contract_scan_result) do
-      FactoryBot.build(:contract_scan_result, :two_title_results)
+      FactoryBot.build(:contract_scan_result, :no_title_v2_results,
+                       :two_title_results)
     end
 
     it "returns the entry with higher sentence score" do


### PR DESCRIPTION
Change result selection to select the result with simply the highest extraction score (score at the "extracted value" level).

> Using the new version is triggered when the scan is started; this logic is extracted, so you can just assume it's already done. Once enabled, the scan key for the title result is "ContractTitle_v2".

Two assumptions are made:

1. That scan results can contain both v1 and v2 scans

2. That v1 with sentence score 0.95 and max extraction score 0.6 has
lower resulting score than a v2 title with score 0.8

minor: picked ContractTitle_V2 over ContractTitle_v2